### PR TITLE
Patch in:

### DIFF
--- a/common/rpm/contrail-analytics.spec
+++ b/common/rpm/contrail-analytics.spec
@@ -200,6 +200,9 @@ install -p -m 755 %{_distropkgdir}/sentinel.conf %{buildroot}%{_contrailetc}/sen
 rm  -f %{buildroot}%{_venv_root}%{_pysitepkg}/gen_py/__init__.*
 rm  -f %{buildroot}%{_venv_root}%{_pysitepkg}/bottle.py*
 
+# install nodemgr
+install -p -m 755 %{_distropkgdir}/contrail-nodemgr.py %{buildroot}%{_venv_root}/bin/contrail-nodemgr
+
 %post
 %if 0%{?fedora} >= 17
 chmod -R 777 /var/log/contrail
@@ -282,6 +285,7 @@ fi
 %if 0%{?fedora} >= 17
 %{_servicedir}/supervisor-analytics.service
 %endif
+%{_venv_root}/bin/contrail-nodemgr
 
 %changelog
 

--- a/common/rpm/contrail-config.spec
+++ b/common/rpm/contrail-config.spec
@@ -81,6 +81,7 @@ scons -U src/discovery
 %define _build_dist %{_builddir}/../build/debug
 %install
 install -d -m 755 %{buildroot}%{_venv_root}
+install -d -m 755 %{buildroot}%{_venv_root}/bin
 
 mkdir -p build/python_dist
 pushd build/python_dist
@@ -164,6 +165,9 @@ install -d -m 777 %{buildroot}%{_localstatedir}/log/contrail
 
 install -D -m 755 %{_distropkgdir}/venv-helper %{buildroot}%{_bindir}/venv-helper
 
+# install nodemgr
+install -p -m 755 %{_distropkgdir}/contrail-nodemgr.py %{buildroot}%{_venv_root}/bin/contrail-nodemgr
+
 %files
 %defattr(-,root,root,-)
 %{_venv_root}%{_pysitepkg}/discovery
@@ -194,6 +198,7 @@ install -D -m 755 %{_distropkgdir}/venv-helper %{buildroot}%{_bindir}/venv-helpe
 %if 0%{?rhel}
 %{_initddir}
 %endif
+%{_venv_root}/bin/contrail-nodemgr
 
 %post
 if [ $1 -eq 1 -a -x /bin/systemctl ] ; then

--- a/common/rpm/contrail-control.spec
+++ b/common/rpm/contrail-control.spec
@@ -81,6 +81,7 @@ install -d -m 755 %{buildroot}%{_contrailetc}
 install -d -m 755 %{buildroot}%{_contrailcontrol}
 install -d -m 755 %{buildroot}%{_supervisordir}
 install -d -m 755 %{buildroot}%{_venv_root}
+install -d -m 755 %{buildroot}%{_venv_root}/bin
 
 pushd %{_builddir}/..
 
@@ -108,7 +109,7 @@ install -p -m 755 %{_distropkgdir}/contrail-control.ini %{buildroot}%{_superviso
  
 install -D -m 644 %{_distropkgdir}/control_param %{buildroot}/etc/contrail/control_param
 install -p -m 755 %{_distropkgdir}/contrail-control.rules %{buildroot}%{_supervisordir}/contrail-control.rules
-
+install -p -m 755 %{_distropkgdir}/contrail-nodemgr.py %{buildroot}%{_venv_root}/bin/contrail-nodemgr
 
 # install pysandesh files
 %define _build_dist %{_builddir}/../build/debug
@@ -159,7 +160,7 @@ popd
 %endif
 
 %config(noreplace) /etc/contrail/control_param
-
+%{_venv_root}/bin/contrail-nodemgr
 
 %post
 (umask 007; /bin/echo "HOSTNAME=$(hostname)" >> /etc/contrail/control_param)

--- a/common/rpm/contrail-vrouter.spec
+++ b/common/rpm/contrail-vrouter.spec
@@ -159,6 +159,9 @@ install -p -m 755 %{_distropkgdir}/supervisord_wrapper_scripts/contrail-vrouter.
 %if 0%(if [ "%{dist}" != ".xen" ]; then echo 1; fi)
 %define _build_dist %{_builddir}/../build/debug
 install -d -m 755 %{buildroot}%{_venv_root}
+install -d -m 755 %{buildroot}%{_venv_root}/bin
+
+install -p -m 755 %{_distropkgdir}/contrail-nodemgr.py %{buildroot}%{_venv_root}/bin/contrail-nodemgr
 
 mkdir -p build/python_dist
 pushd build/python_dist
@@ -184,7 +187,6 @@ pushd discovery-0.1dev
 %{__python} setup.py install --root=%{buildroot}  %{?_venvtr}
 popd
 %endif
-
 
 %post
 %if 0%{?fedora} >= 17
@@ -249,6 +251,7 @@ exit 0
 %{_supervisordir}/contrail-vrouter.ini
 %{_supervisordir}/contrail-vrouter.rules
 %{_supervisordir}/contrail-vrouter.kill
+%{_venv_root}/bin/contrail-nodemgr
 %endif
 %if 0%{?rhel}
 /etc/init.d/contrail-vrouter

--- a/third_party/supervisor.spec
+++ b/third_party/supervisor.spec
@@ -101,7 +101,6 @@ cp dist/* %{buildroot}%{_venv_root}/archive
 popd
 mv %{_distrothirdpartydir}/supervisor-3.0b2/supervisor.egg-info/SOURCES.txt.save %{_distrothirdpartydir}/supervisor-3.0b2/supervisor.egg-info/SOURCES.txt
 mv %{_distrothirdpartydir}/supervisor-3.0b2/supervisor.egg-info/PKG-INFO.save %{_distrothirdpartydir}/supervisor-3.0b2/supervisor.egg-info/PKG-INFO
-install -p -m 755 %{_distropkgdir}/contrail-nodemgr.py %{buildroot}%{_venv_root}/bin/contrail-nodemgr
 # done install in analytics venv
 
 # install in api venv
@@ -128,7 +127,6 @@ cp dist/* %{buildroot}%{_venv_root_api}/archive
 popd
 mv %{_distrothirdpartydir}/supervisor-3.0b2/supervisor.egg-info/SOURCES.txt.save %{_distrothirdpartydir}/supervisor-3.0b2/supervisor.egg-info/SOURCES.txt
 mv %{_distrothirdpartydir}/supervisor-3.0b2/supervisor.egg-info/PKG-INFO.save %{_distrothirdpartydir}/supervisor-3.0b2/supervisor.egg-info/PKG-INFO
-install -p -m 755 %{_distropkgdir}/contrail-nodemgr.py %{buildroot}%{_venv_root_api}/bin/contrail-nodemgr
 #done install in api venv
 
 # install in vrouter venv
@@ -155,7 +153,6 @@ cp dist/* %{buildroot}%{_venv_root_vrouter}/archive
 popd
 mv %{_distrothirdpartydir}/supervisor-3.0b2/supervisor.egg-info/SOURCES.txt.save %{_distrothirdpartydir}/supervisor-3.0b2/supervisor.egg-info/SOURCES.txt
 mv %{_distrothirdpartydir}/supervisor-3.0b2/supervisor.egg-info/PKG-INFO.save %{_distrothirdpartydir}/supervisor-3.0b2/supervisor.egg-info/PKG-INFO
-install -p -m 755 %{_distropkgdir}/contrail-nodemgr.py %{buildroot}%{_venv_root_vrouter}/bin/contrail-nodemgr
 #done install in vrouter venv
 
 # install in control venv
@@ -182,7 +179,6 @@ cp dist/* %{buildroot}%{_venv_root_control}/archive
 popd
 mv %{_distrothirdpartydir}/supervisor-3.0b2/supervisor.egg-info/SOURCES.txt.save %{_distrothirdpartydir}/supervisor-3.0b2/supervisor.egg-info/SOURCES.txt
 mv %{_distrothirdpartydir}/supervisor-3.0b2/supervisor.egg-info/PKG-INFO.save %{_distrothirdpartydir}/supervisor-3.0b2/supervisor.egg-info/PKG-INFO
-install -p -m 755 %{_distropkgdir}/contrail-nodemgr.py %{buildroot}%{_venv_root_control}/bin/contrail-nodemgr
 #done install in control venv
 
 
@@ -214,7 +210,6 @@ install -p -m 755 %{_helper} %{buildroot}%{_bindir}/contrail-nodemgr
 %{_venv_root}/bin/pidproxy
 %{_venv_root}/bin/supervisorctl
 %{_venv_root}/bin/supervisord
-%{_venv_root}/bin/contrail-nodemgr
 %{_venv_root}/archive/supervisor-3.0b2.tar.gz
 %{_venv_root_api}%{_pysitepkg}/supervisor
 %{_venv_root_api}%{_pysitepkg}/supervisor-*
@@ -226,7 +221,6 @@ install -p -m 755 %{_helper} %{buildroot}%{_bindir}/contrail-nodemgr
 %{_venv_root_api}/bin/pidproxy
 %{_venv_root_api}/bin/supervisorctl
 %{_venv_root_api}/bin/supervisord
-%{_venv_root_api}/bin/contrail-nodemgr
 %{_venv_root_api}/archive/supervisor-3.0b2.tar.gz
 %{_venv_root_control}%{_pysitepkg}/supervisor
 %{_venv_root_control}%{_pysitepkg}/supervisor-*
@@ -238,7 +232,6 @@ install -p -m 755 %{_helper} %{buildroot}%{_bindir}/contrail-nodemgr
 %{_venv_root_control}/bin/pidproxy
 %{_venv_root_control}/bin/supervisorctl
 %{_venv_root_control}/bin/supervisord
-%{_venv_root_control}/bin/contrail-nodemgr
 %{_venv_root_control}/archive/supervisor-3.0b2.tar.gz
 %{_venv_root_vrouter}%{_pysitepkg}/supervisor
 %{_venv_root_vrouter}%{_pysitepkg}/supervisor-*
@@ -250,7 +243,6 @@ install -p -m 755 %{_helper} %{buildroot}%{_bindir}/contrail-nodemgr
 %{_venv_root_vrouter}/bin/pidproxy
 %{_venv_root_vrouter}/bin/supervisorctl
 %{_venv_root_vrouter}/bin/supervisord
-%{_venv_root_vrouter}/bin/contrail-nodemgr
 %{_venv_root_vrouter}/archive/supervisor-3.0b2.tar.gz
 %changelog
 * Mon Jul 22 2013 Chandan Mishra <cdmishra@juniper.net> - config-1


### PR DESCRIPTION
commit a9e6a9a7c028f328d201b1e68a309e7258c0f3d2
Author: Megh Bhatt meghb@juniper.net
Date:   Fri Nov 22 01:11:33 2013 -0800

```
1. Remove code that looks at column name to determine the data type
   stored in cassandra in query engine.
2. Install contrail-nodemgr in the control, config, analytics,
   and vrouter venv from the respective rpms instead of from
   the supervisor rpm to support upgrade of individual
   rpms
```
