### PR TITLE
all rpm spec should build specific pysandesh target

### DIFF
--- a/common/rpm/contrail-api-lib.spec
+++ b/common/rpm/contrail-api-lib.spec
@@ -55,7 +55,7 @@ scons -U src/api-lib
 scons -U src/config/common
 scons -U src/discovery/client
 pushd %{_builddir}/../tools/
-scons -U sandesh/library/python
+scons -U sandesh/library/python:pysandesh
 popd
 
 %define _build_dist %{_builddir}/../build/debug

--- a/common/rpm/contrail-config.spec
+++ b/common/rpm/contrail-config.spec
@@ -74,7 +74,7 @@ scons -U src/config/api-server
 scons -U src/config/schema-transformer
 scons -U src/config/svc-monitor
 pushd %{_builddir}/../tools/
-scons -U sandesh/library/python
+scons -U sandesh/library/python:pysandesh
 popd
 scons -U src/discovery
 

--- a/common/rpm/contrail-control.spec
+++ b/common/rpm/contrail-control.spec
@@ -65,7 +65,7 @@ fi
 %build
 scons -U src/sandesh/common
 pushd %{_builddir}/../tools/
-scons -U sandesh/library/python
+scons -U sandesh/library/python:pysandesh
 popd
 scons -U src/discovery
 scons -U src/control-node

--- a/common/rpm/contrail-vrouter.spec
+++ b/common/rpm/contrail-vrouter.spec
@@ -89,7 +89,7 @@ popd
 %if 0%(if [ "%{dist}" != ".xen" ]; then echo 1; fi)
 scons -U src/sandesh/common
 pushd %{_builddir}/../tools/
-scons -U sandesh/library/python
+scons -U sandesh/library/python:pysandesh
 popd
 scons -U src/discovery
 scons -U --target=%{_target_cpu} ${OPT_KERNEL} src/vnsw/agent/uve


### PR DESCRIPTION
Extending the fix to all rpms
