### PR TITLE
bug: 2250 - process_state_list missing in config-node UVE

### DIFF
--- a/common/control_files/contrail-nodemgr.py
+++ b/common/control_files/contrail-nodemgr.py
@@ -384,7 +384,7 @@ def main(argv=sys.argv):
         _disc= client.DiscoveryClient(discovery_server, discovery_port, module_name)
         sandesh_global.init_generator(module_name, socket.gethostname(), 
             node_type_name, instance_id, [ ], module_name, 
-            8100, ['cfgm_common.sandesh'], _disc)
+            8100, ['cfgm_common.uve'], _disc)
         #sandesh_global.set_logging_params(enable_local_log=True)
 
     if (node_type == 'contrail-control'):


### PR DESCRIPTION
- sandesh client initialization [init_generator()] in Config Nodemgr failed to register the UVEs because "sandesh" package was removed from cfgm_common. Therefore, Config Nodemgr failed to send the process_state_list. Replaced cfgm_common.sandesh with cfgm_common.uve in init_generator() for Config Nodemgr.
