### PR TITLE
Do not rename alembic to python-alembic in quantum too

### DIFF
--- a/openstack/debian/Makefile
+++ b/openstack/debian/Makefile
@@ -1,7 +1,7 @@
 PWD := ${CURDIR}
 SB_TOP := $(PWD:/tools/packaging/openstack/debian=)
 
-PACKAGES = openstack-neutron-deb
+PACKAGES = openstack-quantum-deb openstack-neutron-deb
 
 all: ${PACKAGES}
 	@echo "Build complete"
@@ -12,10 +12,13 @@ clean: $(PACKAGES:%-deb=%-clean)
 %-deb:
 	$(eval PKGNAME:=$(@:openstack-%-deb=%))
 	$(eval BUILDDIR=${SB_TOP}/build/openstack/${PKGNAME})
-	mkdir -p ${SB_TOP}/build/openstack
-	cp -R ${SB_TOP}/distro/openstack/${PKGNAME} ${BUILDDIR}
-	cp -R $(@:-deb=)/debian ${BUILDDIR}/debian
-	(cd ${BUILDDIR}; fakeroot debian/rules binary)
+	$(eval DISTRODIR=${SB_TOP}/distro/openstack/${PKGNAME})
+	if test -d ${DISTRODIR}; then \
+		mkdir -p ${SB_TOP}/build/openstack; \
+		cp -R ${SB_TOP}/distro/openstack/${PKGNAME} ${BUILDDIR}; \
+		cp -R $(@:-deb=)/debian ${BUILDDIR}/debian; \
+		(cd ${BUILDDIR}; fakeroot debian/rules binary) \
+	fi
 
 %-clean:
 	$(eval PKGNAME:=$(@:openstack-%-clean=%))

--- a/openstack/debian/openstack-quantum/debian/pydist-overrides
+++ b/openstack/debian/openstack-quantum/debian/pydist-overrides
@@ -1,3 +1,5 @@
 quantum_server quantum-server
 quantum_common quantum-common
 setuptools-git
+jsonrpclib
+alembic alembic


### PR DESCRIPTION
Makefile builds either neutron or quantum, whichever is present in distro/openstack/. This depends on what repo's manifest.xml points to.
