### PR TITLE
contrail-openstack-database files are not there yet

### DIFF
--- a/common/debian/Makefile
+++ b/common/debian/Makefile
@@ -22,7 +22,6 @@ PACKAGES = contrail-libs-deb \
 	contrail-openstack-config-deb \
 	contrail-openstack-deb \
 	contrail-openstack-control-deb \
-	contrail-openstack-database-deb \
 	contrail-openstack-vrouter-deb \
 	contrail-openstack-webui
 


### PR DESCRIPTION
Fix build break wrt contrail-openstack-database. Files are not there yet.
