### PR TITLE
Only pass syslog port value in .ini file

### DIFF
--- a/common/control_files/contrail-collector.ini
+++ b/common/control_files/contrail-collector.ini
@@ -1,5 +1,5 @@
 [program:contrail-collector]
-command= bash -c "/usr/bin/vizd --cassandra-server-list ${CASSANDRA_SERVER_LIST} --discovery-server ${DISCOVERY} --host-ip ${HOST_IP} --listen-port ${LISTEN_PORT} --http-server-port ${HTTP_SERVER_PORT} --analytics-data-ttl ${ANALYTICS_DATA_TTL} ${LOG_LOCAL} ${ANALYTICS_SYSLOG_PORT}"
+command= bash -c "/usr/bin/vizd --cassandra-server-list ${CASSANDRA_SERVER_LIST} --discovery-server ${DISCOVERY} --host-ip ${HOST_IP} --listen-port ${LISTEN_PORT} --http-server-port ${HTTP_SERVER_PORT} --analytics-data-ttl ${ANALYTICS_DATA_TTL} ${LOG_LOCAL} --syslog-port ${ANALYTICS_SYSLOG_PORT}"
 priority=420
 autostart=true
 killasgroup=true

--- a/common/control_files/vizd_param
+++ b/common/control_files/vizd_param
@@ -9,3 +9,4 @@ LOG_FILE=/var/log/contrail/collector.log
 LOG_LOCAL=--log-local
 LOG_LEVEL=SYS_DEBUG
 ANALYTICS_DATA_TTL=168
+ANALYTICS_SYSLOG_PORT=-1


### PR DESCRIPTION
This makes config upgrade easier (to .ini format)
