### PR TITLE
Build vrouter/utils as part of contrail-vrouter build process

### DIFF
--- a/common/debian/contrail-vrouter/debian/rules
+++ b/common/debian/contrail-vrouter/debian/rules
@@ -21,13 +21,13 @@ export _initdir := /etc/init
 export _bindir := /usr/bin
 export _arch := x86_64
 
-BUILD_ARCH_TARGET=src/vnsw/agent:vnswad vrouter vrouter/utils
+BUILD_ARCH_TARGETS=src/vnsw/agent:vnswad vrouter vrouter/utils
 ifdef OSVER
 export _osVer := $(OSVER)
-SCNS :=  scons --kernel-dir=/lib/modules/$(_osVer)/build --target=$(_arch) $(BUILD_ARCH_TARGET)
+SCNS :=  scons --kernel-dir=/lib/modules/$(_osVer)/build --target=$(_arch) $(BUILD_ARCH_TARGETS)
 else
 export _osVer := $(shell uname -r)
-SCNS := scons --target=$(_arch) $(BUILD_ARCH_TARGET)
+SCNS := scons --target=$(_arch) $(BUILD_ARCH_TARGETS)
 endif
 
 BUILDTAG =


### PR DESCRIPTION
Also fix a typo in BUILD_ARCH_TARGETS to BUILD_ARCH_TARGET
