### PR TITLE
For servers with more than 32 CPU cores, the rps_cpus file needs to

### DIFF
--- a/common/control_files/vnagent_ExecStartPre.sh
+++ b/common/control_files/vnagent_ExecStartPre.sh
@@ -28,8 +28,17 @@ function pkt_setup () {
     for f in /sys/class/net/$1/queues/rx-*
     do
         q="$(echo $f | cut -d '-' -f2)"
-        ((mask=1<<$q))
-        echo "obase=16;$mask" | bc > $f/rps_cpus
+        r=$(($q%32))
+        s=$(($q/32))
+        ((mask=1<<$r))
+        str=(`printf "%x" $mask`)
+        if [ $s -gt 0 ]; then
+            for ((i=0; i < $s; i++))
+            do
+                str+=,00000000
+            done
+        fi
+        echo $str > $f/rps_cpus
     done
 }
 


### PR DESCRIPTION
contain entries in the following format

00000001,00000000

Each set of 32 cores needs its own bitmap and these should be comma-separated.
Using a single bitmask with more than 32 bits (without being comma-separated)
will result in an overflow error from the kernel.
