### PR TITLE
Add version less python-django-horizon dependency. With strict verion i....

### DIFF
--- a/common/debian/contrail-ostack-dashboard/debian/grizzly/control
+++ b/common/debian/contrail-ostack-dashboard/debian/grizzly/control
@@ -22,6 +22,7 @@ Architecture: all
 Pre-Depends: dpkg (>= 1.15.7.2)
 Depends: adduser,
  libapache2-mod-wsgi (>= 2.3),
+ python-django-horizon,
  ${misc:Depends},
  ${python:Depends}
 Description: django web interface to Openstack

--- a/common/debian/contrail-ostack-dashboard/debian/havana/control
+++ b/common/debian/contrail-ostack-dashboard/debian/havana/control
@@ -21,5 +21,6 @@ Pre-Depends: dpkg (>= 1.15.7.2)
 Depends: adduser,
  apache2 | httpd,
  libapache2-mod-wsgi (>= 2.3),
+ python-django-horizon,
  ${misc:Depends},
  ${python:Depends}


### PR DESCRIPTION
...e. python-django-horizon (= ) it fails since our version comes in format 1:2013.1.4-0ubuntu1 while openstack stock package format is 1:2013.1.4-0ubuntu1~cloud0
