### PR TITLE
Bug 2333:

### DIFF
--- a/common/control_files/supervisord_analytics.conf
+++ b/common/control_files/supervisord_analytics.conf
@@ -95,7 +95,7 @@ command=/bin/bash -c "HOST_IP=`grep hostip /etc/contrail/collector.conf  | awk '
 environment_file=/etc/contrail/vizd_param
 ;process_name=%(program_name)s ; process_name expr (default %(program_name)s)
 ;numprocs=1                    ; number of processes copies to start (def 1)
-events=PROCESS_COMMUNICATION,PROCESS_STATE
+events=PROCESS_COMMUNICATION,PROCESS_STATE,TICK_60
 buffer_size=10000                ; event buffer queue size (default 10)
 ;directory=/tmp                ; directory to cwd to before exec (def no cwd)
 ;umask=022                     ; umask for process (default None)

--- a/common/control_files/supervisord_config.conf
+++ b/common/control_files/supervisord_config.conf
@@ -92,7 +92,7 @@ serverurl=unix:///tmp/supervisor_config.sock ; use a unix:// URL  for a unix soc
 
 [eventlistener:contrail-config-nodemgr]
 command=/bin/bash -c "source /opt/contrail/api-venv/bin/activate && exec python /opt/contrail/api-venv/bin/contrail-nodemgr --rules=/etc/contrail/supervisord_config_files/contrail-config.rules --nodetype=contrail-config"
-events=PROCESS_COMMUNICATION,PROCESS_STATE
+events=PROCESS_COMMUNICATION,PROCESS_STATE,TICK_60
 ;[eventlistener:theeventlistenername]
 ;command=/bin/eventlistener    ; the program (relative uses PATH, can take args)
 ;process_name=%(program_name)s ; process_name expr (default %(program_name)s)

--- a/common/control_files/supervisord_control.conf
+++ b/common/control_files/supervisord_control.conf
@@ -92,7 +92,7 @@ serverurl=unix:///tmp/supervisor_control.sock ; use a unix:// URL  for a unix so
 
 [eventlistener:contrail-control-nodemgr]
 command=/bin/bash -c "DISCOVERY=`grep \"discovery-server IP address\" /etc/contrail/control-node.conf  | awk '{print $1}' | awk -F '=' '{print $2}'` && source /opt/contrail/control-venv/bin/activate && exec python /opt/contrail/control-venv/bin/contrail-nodemgr --rules=/etc/contrail/supervisord_control_files/contrail-control.rules --nodetype=contrail-control  --discovery_server=${DISCOVERY}"
-events=PROCESS_COMMUNICATION,PROCESS_STATE
+events=PROCESS_COMMUNICATION,PROCESS_STATE,TICK_60
 environment_file= /etc/contrail/control_param
 ;[eventlistener:theeventlistenername]
 ;command=/bin/eventlistener    ; the program (relative uses PATH, can take args)


### PR DESCRIPTION
This bug is to update the start_time of various processes started by the different supervisord's whenever system time changes. Node manager is made to listen to TICK_60 event in all the supervisord's and when event happens we check for any system time changes and if it occurs we update the start_time,stop_time,exit_time and send the uve to collector.
