### PR TITLE
removing checks for default_pmac and agent_param files in vrouter-pre-st...

### DIFF
--- a/common/control_files/vrouter-pre-start.sh
+++ b/common/control_files/vrouter-pre-start.sh
@@ -25,10 +25,6 @@ mac=$1;
 done
 }
 
-
-[ -f /etc/contrail/default_pmac ] || error_exit $LINENO "Did you run setup?"
-[ -f /etc/contrail/agent_param ] || error_exit $LINENO "Did you run setup?"
-
 source /opt/contrail/bin/vrouter-function.sh
 
 function create_virtual_gateway() {


### PR DESCRIPTION
...art.sh to make sure that OCS installation goes through without running fab setup
