### PR TITLE
In havana/control add missing description for openstack-dashboard

### DIFF
--- a/common/debian/contrail-ostack-dashboard/debian/grizzly/control
+++ b/common/debian/contrail-ostack-dashboard/debian/grizzly/control
@@ -25,7 +25,7 @@ Depends: adduser,
  python-django-horizon,
  ${misc:Depends},
  ${python:Depends}
-Description: django web interface to Openstack
+Description: django web interface to Openstack built by Contrail
  The OpenStack Dashboard is a reference implementation of a Django site that
  uses the Django-Nova project to provide web based interactions with the
  OpenStack Nova cloud controller.

--- a/common/debian/contrail-ostack-dashboard/debian/havana/control
+++ b/common/debian/contrail-ostack-dashboard/debian/havana/control
@@ -24,3 +24,7 @@ Depends: adduser,
  python-django-horizon,
  ${misc:Depends},
  ${python:Depends}
+Description: django web interface to Openstack built by Contrail
+ The OpenStack Dashboard is a reference implementation of a Django site that
+ uses the Django-Nova project to provide web based interactions with the
+ OpenStack Nova cloud controller.


### PR DESCRIPTION
In havana/control add missing description for openstack-dashboard
