### PR TITLE
Force remove contrail-openstack-dashboard's JS reference from Horizon paths

### DIFF
--- a/common/debian/contrail-openstack-dashboard/debian/havana/contrail-openstack-dashboard.postrm
+++ b/common/debian/contrail-openstack-dashboard/debian/havana/contrail-openstack-dashboard.postrm
@@ -1,0 +1,11 @@
+#!/bin/sh
+# vim: set ts=2 et:
+
+set -e
+
+if [ "$1" = "remove" ] || [ "$1" = "purge" ] ; then
+  if [ -e /usr/share/openstack-dashboard/openstack_dashboard/static/dashboard/js/contrail.networktopology.js ] ; then
+    rm -f /usr/share/openstack-dashboard/openstack_dashboard/static/dashboard/js/contrail.networktopology.js
+  fi
+fi
+#DEBHELPER#


### PR DESCRIPTION
Force remove contrail-openstack-dashboard's JS reference from Horizon paths
