### PR TITLE
adding support for python-neutronclient to build with contrail source, u...

### DIFF
--- a/build/pkg_configs/centos/havana/contrail_packages.cfg
+++ b/build/pkg_configs/centos/havana/contrail_packages.cfg
@@ -130,6 +130,10 @@ makeloc   = tools/packaging/common/rpm
 pkgs      = contrail-database
 makeloc   = tools/packaging/common/rpm
 
+[neutronclient]
+pkgs      = python-neutronclient
+makeloc   = tools/packaging/third_party/
+
 [contrail-fabric-utils]
 pkgs      = contrail-fabric-utils
 makeloc   = tools/packaging/third_party/

--- a/build/pkg_configs/centos/havana/depends_centos_6.4_pkgs.cfg
+++ b/build/pkg_configs/centos/havana/depends_centos_6.4_pkgs.cfg
@@ -1519,10 +1519,6 @@ md5   = 03de6b1b431d893fd0437e417452ebfb
 file  = python-migrate-0.7.2-8.el6.noarch.rpm
 md5   = 875ea2d6f44a070c8d9918d5378da706
 
-[python-neutronclient]
-file  = python-neutronclient-2.3.1-3.el6.noarch.rpm
-md5   = dc7530571575244076ea651b132901d5
-
 [python-novaclient]
 file  = python-novaclient-2.16.0-2.el6.noarch.rpm
 md5   = affc3157f531de691fcbd52faf1f0eb7

--- a/common/rpm/contrail-api-venv.spec
+++ b/common/rpm/contrail-api-venv.spec
@@ -92,9 +92,11 @@ cat > reqs/reqs.txt <<END
 %{_builddir}/../%{_distrothirdpartydir}/anyjson-0.3.3.tar.gz
 %{_builddir}/../%{_distrothirdpartydir}/kombu-3.0.9.tar.gz
 %if %{_skuTag} != "grizzly"
+%{_builddir}/../%{_distrothirdpartydir}/six-1.6.1.tar.gz
+%{_builddir}/../%{_distrothirdpartydir}/Babel-1.3.tar.gz
+%{_builddir}/../%{_distrothirdpartydir}/pytz-2014.2.tar.gz 
 %{_builddir}/../%{_distrothirdpartydir}/python-novaclient-3776fe9.tar.gz
 %{_builddir}/../%{_distrothirdpartydir}/python-keystoneclient-0.0.360.0b66ca5.tar.gz
-%{_builddir}/../%{_distrothirdpartydir}/python-neutronclient.tar.gz
 %endif
 END
 

--- a/third_party/Makefile
+++ b/third_party/Makefile
@@ -106,7 +106,14 @@ package-python-swiftclient:
 
 all-openstack-client: $(PREP) cinderclient glanceclient keystoneclient novaclient quantumclient \
 	swiftclient
+else
+neutronclient:package-python-neutronclient
+python-neutronclient:package-python-neutronclient
+package-python-neutronclient:
+	@echo making rpm for package-python-neutronclient
+	rpmbuild $(RPMBLDOPTS) python-neutronclient.spec $(G_TAG)
 
+all-openstack-client: $(PREP) neutronclient
 endif
 
 # Other 3rd party packages
@@ -220,13 +227,11 @@ xmltodict: $(PREP)
 ifeq ($(CONTRAIL_SKU), grizzly)
 all: $(PREP) all-openstack-client contrail-fabric-utils contrail-test euca2ools hiredis-py \
 	ifmap-server python-boto libvirt puppet python-bitarray python-geventhttpclient \
-	libvirt puppet python-bitarray python-geventhttpclient python-pycassa python-thrift \
-	redis-py supervisor webob xmltodict ixgbe
+	python-pycassa python-thrift redis-py supervisor webob xmltodict ixgbe
 else
-all: $(PREP) contrail-fabric-utils contrail-test euca2ools hiredis-py \
+all: $(PREP) all-openstack-client contrail-fabric-utils contrail-test euca2ools hiredis-py \
 	ifmap-server python-boto libvirt puppet python-bitarray python-geventhttpclient \
-	libvirt puppet python-bitarray python-geventhttpclient python-pycassa python-thrift \
-	redis-py supervisor xmltodict ixgbe
+	python-pycassa python-thrift redis-py supervisor xmltodict ixgbe
 endif
 clean:
 	@echo clean

--- a/third_party/python-neutronclient.spec
+++ b/third_party/python-neutronclient.spec
@@ -1,0 +1,98 @@
+#
+# This is 2.3.0 havana
+#
+%if 0%{?_buildTag:1}
+%define         _relstr      %{_buildTag}
+%else
+%define         _relstr      %(date -u +%y%m%d%H%M)
+%endif
+%{echo: "Building release %{_relstr}\n"}
+
+Name:       python-neutronclient
+Version:    2.3.0
+Epoch:      2
+Release:    1%{_relstr}
+Summary:    Python API and CLI for OpenStack Neutron
+
+Group:      Development/Languages
+License:    ASL 2.0
+URL:        http://launchpad.net/python-neutronclient/
+#Source0:    https://pypi.python.org/packages/source/p/%{name}/%{name}-%{version}.tar.gz
+
+#
+# patches_base=2.3.0
+#
+#Patch0001: 0001-Remove-runtime-dependency-on-python-pbr.patch
+
+Obsoletes:  python-quantumclient < 2:2.2.4
+
+BuildArch:  noarch
+
+BuildRequires: python2-devel
+BuildRequires: python-setuptools
+BuildRequires: python-pbr
+BuildRequires: python-d2to1
+
+Requires: pyparsing
+Requires: python-httplib2
+Requires: python-cliff >= 1.0
+Requires: python-prettytable >= 0.6
+Requires: python-setuptools
+Requires: python-simplejson
+
+%description
+Client library and command line utility for interacting with Openstack
+Neutron's API.
+
+%prep
+pushd %{_builddir}/..
+pushd third_party/python-neutronclient
+#%setup -q -n %{name}-%{version}
+#%patch0001 -p1
+# We provide version like this in order to remove runtime dep on pbr.
+#sed -i s/REDHATNEUTRONCLIENTVERSION/%{version}/ neutronclient/version.py
+sed -i 's/Babel>=0.9.6/Babel/' requirements.txt
+
+%build
+pushd %{_builddir}/..
+pushd third_party/python-neutronclient
+%{__python} setup.py build
+
+%install
+pushd %{_builddir}/..
+pushd third_party/python-neutronclient
+%{__python} setup.py install -O1 --skip-build --root %{buildroot} %{?_venvtr}
+%{__python} setup.py sdist
+install -p -D -m 644 dist/python-neutronclient-2.3.0.18.gb0c191c.tar.gz %{buildroot}/opt/contrail/api-venv/archive/python-neutronclient-2.3.0.18.gb0c191c.tar.gz
+
+# Install other needed files
+# rhbz 888939#c7: bash-completion is not in RHEL
+install -p -D -m 644 tools/neutron.bash_completion \
+    %{buildroot}%{_sysconfdir}/profile.d/neutron.sh
+popd
+
+# Remove unused files
+rm -rf %{buildroot}%{python_sitelib}/neutronclient/tests
+
+%files
+#%doc LICENSE
+#%doc README.rst
+%{_bindir}/neutron
+%{python_sitelib}/neutronclient
+%{python_sitelib}/*.egg-info
+%{_sysconfdir}/profile.d/neutron.sh
+/opt/contrail/api-venv/archive/python-neutronclient-2.3.0.18.gb0c191c.tar.gz
+
+%changelog
+* Mon Sep 09 2013 Jakub Ruzicka <jruzicka@redhat.com> - 2.3.0-1
+- Update to upstream 2.3.0.
+
+* Wed Aug 28 2013 Jakub Ruzicka <jruzicka@redhat.com> - 2.2.6-2
+- Remove all pbr deps in the patch instead of this spec file.
+
+* Tue Aug 27 2013 Jakub Ruzicka <jruzicka@redhat.com> - 2.2.6-1
+- Update to upstream 2.2.6.
+
+* Tue Jul 23 2013 Jakub Ruzicka <jruzicka@redhat.com> - 1:2.2.4-1
+- Initial package based on python-quantumclient.
+- Removed runtime dependency on python-pbr.


### PR DESCRIPTION
...pdate api-venv only for havana to satisfy python-neutronclient requirements by installing pytz, six and Babel in api-venv
