### PR TITLE
Move temp build dirs to debian; Reprint error logs at the end of the pac...

### DIFF
--- a/build/libs/packager/centos_packager.py
+++ b/build/libs/packager/centos_packager.py
@@ -5,7 +5,7 @@ import logging
 
 from common import BasePackager
 
-log = logging.getLogger("pkg.%s" %__name__)
+log = logging.getLogger("pkg")
         
 class Packager(BasePackager):
     ''' Centos Packager '''

--- a/build/libs/packager/common.py
+++ b/build/libs/packager/common.py
@@ -12,12 +12,13 @@ import getpass
 import tempfile
 import operator
 import platform
+import traceback
 from lxml import etree
 from xml.etree import ElementTree
 
 from utils import Utils
 
-log = logging.getLogger("pkg.%s" %__name__)
+log = logging.getLogger("pkg")
 PLATFORM = Utils.get_platform_info()
 
 class BasePackager(Utils):
@@ -97,6 +98,7 @@ class BasePackager(Utils):
                 log.info('\n')
             except:
                 self.exec_status = 255
+                log.error(traceback.format_exc())
                 log.error('Packager Failed for Type (%s)' % pkgtype)
                 log.error('Skipping rest of the steps for Type (%s)' % pkgtype)
           

--- a/build/libs/packager/fedora_packager.py
+++ b/build/libs/packager/fedora_packager.py
@@ -5,7 +5,7 @@ import logging
 
 from common import BasePackager
 
-log = logging.getLogger("pkg.%s" %__name__)
+log = logging.getLogger("pkg")
         
 class Packager(BasePackager):
     ''' Fedora Packager '''

--- a/build/libs/packager/redhat_packager.py
+++ b/build/libs/packager/redhat_packager.py
@@ -5,7 +5,7 @@ import logging
 
 from common import BasePackager
 
-log = logging.getLogger("pkg.%s" %__name__)
+log = logging.getLogger("pkg")
 
 
 class Packager(BasePackager):

--- a/build/libs/packager/ubuntu_packager.py
+++ b/build/libs/packager/ubuntu_packager.py
@@ -5,7 +5,7 @@ import logging
 
 from common import BasePackager
 
-log = logging.getLogger("pkg.%s" %__name__)
+log = logging.getLogger("pkg")
 
 
 class Packager(BasePackager):

--- a/build/libs/packager/utils.py
+++ b/build/libs/packager/utils.py
@@ -22,7 +22,7 @@ import subprocess
 
 from ConfigParser import SafeConfigParser
 
-log = logging.getLogger("pkg.%s" %__name__)
+log = logging.getLogger("pkg")
 
 class Utils(object):
     ''' Utilities for packager '''
@@ -78,8 +78,9 @@ class Utils(object):
             out = self.read_async(fd)
             if out:
                 sys.stdout.write(out)
-                log.parent.handlers[1].stream.write(out)
-                log.parent.handlers[1].stream.flush()
+                log.handlers[1].stream.write(out)
+                log.handlers[1].stream.flush()
+
 
     def make_async(self, fd):
         '''add O_NONBLOCK flag to a file descriptor'''
@@ -102,7 +103,7 @@ class Utils(object):
         if proc.returncode != 0:
             log.error(stdout)
             log.error(stderr)
-            raise RuntimeError('Cmd: %s; **FAILED**' %cmd)
+            raise RuntimeError('cd %s; Cmd: %s; **FAILED**' % (wd, cmd))
         return stdout.strip('\n'), stderr.strip('\n')
   
     def exec_cmd(self, cmd, wd=''):
@@ -127,7 +128,7 @@ class Utils(object):
         proc.communicate()
         if proc.returncode != 0:
             log.error('Cmd: %s; **FAILED**' %cmd)
-            raise RuntimeError('Cmd: %s; **FAILED**' %cmd)
+            raise RuntimeError('cd %s; Cmd: %s; **FAILED**' % (wd, cmd))
         
     @staticmethod
     def get_as_list(elm):

--- a/build/packager.py
+++ b/build/packager.py
@@ -14,6 +14,8 @@ import pprint
 import datetime
 import logging.config
 
+from logger import logger
+logging.setLoggerClass(logger.PackagerLogger)
 from libs.packager.utils import Utils
 from templates import comps_xml
 
@@ -22,7 +24,7 @@ sys.path.append(os.path.abspath(os.path.join('libs', 'packager')))
 PLATFORM = Utils.get_platform_info()
 packager = __import__('%s_packager' % PLATFORM[0])
 
-log = logging.getLogger("pkg.%s" %__name__)
+log = logging.getLogger("pkg")
 
 class PackagerArgParser(Utils):
     ''' Argument parser for Packager '''
@@ -261,6 +263,7 @@ if __name__ == '__main__':
     try:
         packer.ks_build()
     except:
+        packer.exec_status = 1
         raise
     else:
         if packer.exec_status != 0:
@@ -269,6 +272,12 @@ if __name__ == '__main__':
         log.info('Copying available built ' \
                  'packages to (%s)' %packer.artifacts_dir)
         packer.copy_to_artifacts()
+        if packer.exec_status != 0:
+            log.info('*' * 78)
+            log.info('Packager Completed with ERRORs...')
+            log.info('Reprinting ALL ERRORS...')
+            log.reprint_errors()
+            log.error('View Detailed logs at (%s)' % args.cliargs['logfile'])
 
     duration = datetime.datetime.now() - start
     log.info('Execution Duration: %s' %str(duration))

--- a/common/debian/Makefile
+++ b/common/debian/Makefile
@@ -4,8 +4,9 @@ SRC_VER := $(shell cat $(SB_TOP)/controller/src/base/version.info)
 BUILDTIME := $(shell date -u +%y%m%d%H%M)
 
 ifdef CONTRAIL_SKU
+  export CONTRAIL_SKU
 else
-  CONTRAIL_SKU := havana
+  export CONTRAIL_SKU := havana
 endif
 
 VERSION = 
@@ -70,26 +71,27 @@ ifmap-server-clean:
 	rm -rf ${BUILDDIR}
 
 contrail-install-packages-deb:
-	$(eval BUILDDIR=${SB_TOP}/build/contrail-install-packages)
+	$(eval BUILDDIR=${SB_TOP}/build/debian/contrail-install-packages)
 	mkdir -p ${BUILDDIR}
 	cp -ar ${SB_TOP}/tools/packaging/common/debian/contrail-install-packages/debian ${BUILDDIR}
 	(cd ${BUILDDIR}; fakeroot debian/rules clean)
-	(cd ${BUILDDIR}; fakeroot debian/rules binary && mv ../contrail-install-packages_*_all.deb ../debian/)
-	@echo "Wrote: ${BUILDDIR}/../debian/contrail-install-packages_*_all.deb"
+	(cd ${BUILDDIR}; fakeroot debian/rules binary)
+	@echo "Wrote: ${BUILDDIR}/../contrail-install-packages_$(VERSION)~$(CONTRAIL_SKU)_all.deb"
 
 contrail-install-packages-clean:
-	$(eval BUILDDIR=${SB_TOP}/build/contrail-install-packages)
+	$(eval BUILDDIR=${SB_TOP}/build/debian/contrail-install-packages)
 	rm -rf ${BUILDDIR}
 
 contrail-storage-packages-deb:
-	$(eval BUILDDIR=${SB_TOP}/build/contrail-storage-packages)
+	$(eval BUILDDIR=${SB_TOP}/build/debian/contrail-storage-packages)
 	mkdir -p ${BUILDDIR}
 	cp -ar ${SB_TOP}/tools/packaging/common/debian/contrail-storage-packages/debian ${BUILDDIR}
-	(cd ${BUILDDIR}; fakeroot debian/rules binary && mv ../contrail-storage-packages_*_all.deb ../debian/)
-	@echo "Wrote: ${BUILDDIR}/../debian/contrail-storage-packages_*_all.deb"
+	(cd ${BUILDDIR}; fakeroot debian/rules clean)
+	(cd ${BUILDDIR}; fakeroot debian/rules binary)
+	@echo "Wrote: ${BUILDDIR}/../contrail-storage-packages_$(VERSION)~$(CONTRAIL_SKU)_all.deb"
 
 contrail-storage-packages-clean:
-	$(eval BUILDDIR=${SB_TOP}/build/contrail-storage-packages)
+	$(eval BUILDDIR=${SB_TOP}/build/debian/contrail-storage-packages)
 	rm -rf ${BUILDDIR}
 
 contrail-fabric-utils-deb:

--- a/common/debian/contrail-install-packages/debian/rules
+++ b/common/debian/contrail-install-packages/debian/rules
@@ -8,11 +8,10 @@
 # Uncomment this to turn on verbose mode.
 export DH_VERBOSE=1
 SPEC_DIR := $(shell pwd)
-export SB_TOP := $(shell pwd | sed -re "s/\/build\/contrail-install-packages//g")
+export SB_TOP := $(shell pwd | sed -re "s/\/build\/debian\/contrail-install-packages//g")
 
 export BUILDTIME := $(shell date -u +%y%m%d%H%M)
-export buildroot := $(SB_TOP)/build/contrail-install-packages/debian/contrail-install-packages
-export LD_LIBRARY_PATH := $(LD_LIBRARY_PATH):debian/contrail-analytics/usr/lib64/contrail:debian/contrail-libs/usr/lib64/contrail
+export buildroot := $(SB_TOP)/build/debian/contrail-install-packages/debian/contrail-install-packages
 export _contrailopt := /opt/contrail
 
 SRC_VER := $(shell cat $(SB_TOP)/controller/src/base/version.info)

--- a/common/debian/contrail-storage-packages/debian/rules
+++ b/common/debian/contrail-storage-packages/debian/rules
@@ -8,10 +8,10 @@
 # Uncomment this to turn on verbose mode.
 export DH_VERBOSE=1
 SPEC_DIR := $(shell pwd)
-export SB_TOP := $(shell pwd | sed -re "s/\/build\/contrail-storage-packages//g")
+export SB_TOP := $(shell pwd | sed -re "s/\/build\/debian\/contrail-storage-packages//g")
 
 export BUILDTIME := $(shell date -u +%y%m%d%H%M)
-export buildroot := $(SB_TOP)/build/contrail-storage-packages/debian/contrail-storage-packages
+export buildroot := $(SB_TOP)/build/debian/contrail-storage-packages/debian/contrail-storage-packages
 export _contrailopt := /opt/contrail
 
 SRC_VER := $(shell cat $(SB_TOP)/controller/src/base/version.info)


### PR DESCRIPTION
1. In case of failure, Packager is printing the error message and moving to next packaging. This doesnt help debugging as the error messages are not easily visibile. Reprint error logs at the end of the packager in case of failure
2. move build temp build dir of contrail-storage and contrial-install to debian dir.
