### PR TITLE
Revert "make the supervisord conf & ini files as config-no-replace"

### DIFF
--- a/common/rpm/contrail-analytics.spec
+++ b/common/rpm/contrail-analytics.spec
@@ -232,11 +232,11 @@ fi
 %{_bindir}/contrail_collector_pre
 %{_bindir}/contrail_qe_pre
 %{_venv_root}
-%config(noreplace) %{_supervisordir}/contrail-collector.ini
-%config(noreplace) %{_supervisordir}/contrail-opserver.ini
-%config(noreplace) %{_supervisordir}/contrail-qe.ini
-%config(noreplace) %{_supervisordir}/redis-query.ini
-%config(noreplace) %{_supervisordir}/redis-uve.ini
+%{_supervisordir}/contrail-collector.ini
+%{_supervisordir}/contrail-opserver.ini
+%{_supervisordir}/contrail-qe.ini
+%{_supervisordir}/redis-query.ini
+%{_supervisordir}/redis-uve.ini
 %{_supervisordir}/contrail-analytics.rules
 %if 0%{?rhel}
 %{_initddir}/supervisor-analytics
@@ -263,7 +263,7 @@ fi
 /usr/share/doc/python-vnc_opserver
 %config(noreplace) %{_contrailetc}/redis-query.conf
 %config(noreplace) %{_contrailetc}/redis-uve.conf
-%config(noreplace) %{_contrailetc}/supervisord_analytics.conf
+%{_contrailetc}/supervisord_analytics.conf
 %if 0%{?fedora} >= 17
 %{_servicedir}/supervisor-analytics.service
 %endif

--- a/common/rpm/contrail-config.spec
+++ b/common/rpm/contrail-config.spec
@@ -191,11 +191,6 @@ install -p -m 755 %{_distropkgdir}/contrail-nodemgr.py %{buildroot}%{_venv_root}
 #%{_bindir}/encap.py
 %{_initddir}
 %{_venv_root}/bin/contrail-nodemgr
-%config(noreplace) %{_sysconfdir}/contrail/supervisord_config.conf
-%config(noreplace) %{_sysconfdir}/contrail/supervisord_config_files/contrail-api.ini
-%config(noreplace) %{_sysconfdir}/contrail/supervisord_config_files/contrail-schema.ini
-%config(noreplace) %{_sysconfdir}/contrail/supervisord_config_files/contrail-svc-monitor.ini
-%config(noreplace) %{_sysconfdir}/contrail/supervisord_config_files/contrail-discovery.ini
 %config(noreplace) %{_sysconfdir}/contrail/api_server.conf
 %config(noreplace) %{_sysconfdir}/contrail/schema_transformer.conf
 %config(noreplace) %{_sysconfdir}/contrail/svc_monitor.conf

--- a/common/rpm/contrail-control.spec
+++ b/common/rpm/contrail-control.spec
@@ -143,7 +143,7 @@ popd
 %defattr(-,root,root,-)
 %{_bindir}/control-node
 %{_supervisordir}
-%config(noreplace) %{_contrailetc}/supervisord_control.conf
+%{_contrailetc}/supervisord_control.conf
 %{_venv_root}
 /usr/share/doc/
 %if 0%{?fedora} >= 17
@@ -161,7 +161,6 @@ popd
 
 %config(noreplace) /etc/contrail/control_param
 %{_venv_root}/bin/contrail-nodemgr
-%config(noreplace) %{_supervisordir}/contrail-control.ini
 
 %post
 (umask 007; /bin/echo "HOSTNAME=$(hostname)" >> /etc/contrail/control_param)

--- a/common/rpm/contrail-database.spec
+++ b/common/rpm/contrail-database.spec
@@ -86,7 +86,7 @@ fi
 %doc
 %{_sysconfdir}/rc.d/init.d/contrail-database
 %{_sysconfdir}/rc.d/init.d/supervisord-contrail-database
-%config(noreplace) %{_sysconfdir}/contrail/supervisord_contrail_database.conf
+%{_sysconfdir}/contrail/supervisord_contrail_database.conf
 
 %changelog
 * Wed Dec 12 2012 Pedro Marques <roque@build02> - 

--- a/common/rpm/contrail-vrouter.spec
+++ b/common/rpm/contrail-vrouter.spec
@@ -250,8 +250,8 @@ exit 0
 %{_contrailetc}/vnagent_param_setup.sh
 %{_contrailetc}/contrail_reboot
 %{_servicedir}/supervisor-vrouter.service
-%config(noreplace) %{_contrailetc}/supervisord_vrouter.conf
-%config(noreplace) %{_supervisordir}/contrail-vrouter.ini
+%{_contrailetc}/supervisord_vrouter.conf
+%{_supervisordir}/contrail-vrouter.ini
 %{_supervisordir}/contrail-vrouter.rules
 %{_supervisordir}/contrail-vrouter.kill
 %{_venv_root}/bin/contrail-nodemgr

--- a/common/rpm/contrail-webui.spec
+++ b/common/rpm/contrail-webui.spec
@@ -120,9 +120,10 @@ rm -rf %{_specdir}/contrail-webui.spec
 %endif
 %{_libdir}/*
 %config(noreplace) %{_contrailetc}/config.global.js
-%config(noreplace) %{_supervisordir}/*
-%config(noreplace) %{_contrailetc}/supervisord_webui.conf
-%config(noreplace) %{_contrailetc}/redis-webui.conf
+%{_supervisordir}/*
+%{_contrailetc}/supervisord_webui.conf
+%{_contrailetc}/redis-webui.conf
+
 
 %post
 %if 0%{?rhel}


### PR DESCRIPTION
This reverts commit 6bbfaab174a4e680e39eae69f234153946225e36.

Conflicts:

```
common/rpm/contrail-config.spec
```

since the supervisord conf and ini files have changed quite a bit
between R1.04 and R1.05, for R1.05 we are going w/ what's in the
package for these files.. Going forward we will keep the old
files on upgrade..
