### PR TITLE
Upgrade libssl in ubuntu and openssl in centos

### DIFF
--- a/build/package_configs/centos64/grizzly/depends_packages.cfg
+++ b/build/package_configs/centos64/grizzly/depends_packages.cfg
@@ -1605,12 +1605,8 @@ file = mesa-private-llvm-3.3-0.3.rc3.el6.x86_64.rpm
 md5  = df244d55c46e20a7de47c3a58c6f0869
 
 [openssl]
-file = openssl-1.0.1e-16.el6_5.4.i686.rpm
-md5  = 5aa2d75fb9c37358efcd0410ac61d7ac
-
-[openssl]
-file = openssl-1.0.1e-16.el6_5.4.x86_64.rpm
-md5  = 1ba4425a3f791e1a5b3547f42e74c112
+file = openssl-1.0.1e-16.el6_5.7.x86_64.rpm
+md5  = 4d13d3df8275165f778e8d024506505f
 
 [rabbitmq-server]
 file = rabbitmq-server-3.2.2-1.noarch.rpm

--- a/build/package_configs/centos64/havana/depends_packages.cfg
+++ b/build/package_configs/centos64/havana/depends_packages.cfg
@@ -1409,8 +1409,8 @@ file  = novnc-0.4-8.el6.noarch.rpm
 md5   = f1ab9630a13f5bd4bbe0741f7063e75f
 
 [openssl]
-file  = openssl-1.0.1e-16.el6_5.4.x86_64.rpm
-md5   = e406d3215b778ef2bf7911e7ae79a185
+file = openssl-1.0.1e-16.el6_5.7.x86_64.rpm
+md5  = 4d13d3df8275165f778e8d024506505f
 
 [openstack-cinder]
 file  = openstack-cinder-2013.2.2-1.el6.noarch.rpm

--- a/build/package_configs/ubuntu1204/havana/depends_packages.cfg
+++ b/build/package_configs/ubuntu1204/havana/depends_packages.cfg
@@ -537,8 +537,8 @@ file  = libspice-server1_0.12.4-0nocelt1~cloud1_amd64.deb
 md5   = 4fd6a6d2334bb5019b7998d4da6f3904
 
 [libssl1.0.0]
-file  = libssl1.0.0_1.0.1-4ubuntu5.11_amd64.deb
-md5   = 6365b26cb7aa14f0792c971c5276f7e6
+file  = libssl1.0.0_1.0.1-4ubuntu5.12_amd64.deb
+md5   = 0a84a368338f1a6839d880a9bd81af7c
 
 [libsslcommon2]
 file  = libsslcommon2_0.14-2_amd64.deb


### PR DESCRIPTION
Upgrade openssl/libssl depends packages
1. Upgrade libssl to libssl1.0.0_1.0.1-4ubuntu5.12_amd64.deb
2. Upgrade openssl to openssl-1.0.1e-16.el6_5.7.x86_64.rpm
