### PR TITLE
packages analytics: preserving backward compatibility

### DIFF
--- a/common/debian/contrail-analytics/debian/rules
+++ b/common/debian/contrail-analytics/debian/rules
@@ -96,8 +96,8 @@ override_dh_auto_install:
 	install -D -m 755 ${SB_TOP}/controller/src/opserver/contrail-flows $(buildroot)$(_bindir)/contrail-flows
 
 	install -D -m 644 $(_src_config)/vizd_param $(buildroot)/$(_sysconfdir)/contrail/vizd_param
-	install -D -m 644 $(SB_TOP)/controller/src/analytics/collector.conf $(buildroot)/$(_sysconfdir)/contrail/collector.conf
-	install -D -m 644 $(SB_TOP)/controller/src/query_engine/query-engine.conf $(buildroot)/$(_sysconfdir)/contrail/query-engine.conf
+	install -D -m 644 $(SB_TOP)/controller/src/analytics/contrail-collector.conf $(buildroot)/$(_sysconfdir)/contrail/collector.conf
+	install -D -m 644 $(SB_TOP)/controller/src/query_engine/contrail-query-engine.conf $(buildroot)/$(_sysconfdir)/contrail/query-engine.conf
 	install -D -m 644 $(_src_config)/qe_param $(buildroot)/$(_sysconfdir)/contrail/qe_param
 	install -D -m 644 $(_src_config)/opserver_param $(buildroot)/$(_sysconfdir)/contrail/opserver_param
 

--- a/common/rpm/contrail-analytics.spec
+++ b/common/rpm/contrail-analytics.spec
@@ -153,8 +153,8 @@ pushd %{_builddir}/..
 install -p -m 755 build/debug/analytics/vizd    %{buildroot}%{_bindir}/vizd
 install -p -m 755 build/debug/query_engine/qed  %{buildroot}%{_bindir}/qed
 install -p -m 755 %{_distropkgdir}/contrail-analytics.rules %{buildroot}%{_supervisordir}/contrail-analytics.rules
-install -D -m 644 controller/src/analytics/collector.conf %{buildroot}/%{_contrailetc}/collector.conf
-install -D -m 644 controller/src/query_engine/query-engine.conf %{buildroot}/%{_contrailetc}/query-engine.conf
+install -D -m 644 controller/src/analytics/contrail-collector.conf %{buildroot}/%{_contrailetc}/collector.conf
+install -D -m 644 controller/src/query_engine/contrail-query-engine.conf %{buildroot}/%{_contrailetc}/query-engine.conf
 
 #install wrapper scripts for supervisord
 install -p -m 755 %{_distropkgdir}/supervisord_wrapper_scripts/contrail_collector_pre  %{buildroot}%{_bindir}/contrail_collector_pre


### PR DESCRIPTION
conf files are renamed, but retained its name for existing build system
