### PR TITLE
No need to pass default config file path as command line argument for ag...

### DIFF
--- a/common/control_files/contrail-vrouter.ini
+++ b/common/control_files/contrail-vrouter.ini
@@ -1,5 +1,5 @@
 [program:contrail-vrouter]
-command= bash -c "/usr/bin/vnswad --config-file /etc/contrail/agent.conf"
+command=/usr/bin/vnswad
 priority=420
 autostart=true
 killasgroup=true


### PR DESCRIPTION
...ent.
