### PR TITLE
remove version name from nova.egg-info, otherwise build is failing due t...

### DIFF
--- a/openstack/centos_64/nova/openstack-nova.spec
+++ b/openstack/centos_64/nova/openstack-nova.spec
@@ -887,7 +887,7 @@ fi
 %defattr(-,root,root,-)
 %doc nova/LICENSE
 %{python_sitelib}/nova
-%{python_sitelib}/nova-%{version}*.egg-info
+%{python_sitelib}/nova-*.egg-info
 
 %if 0%{?with_doc}
 %files doc


### PR DESCRIPTION
...o new tag in v1.05, this is specific to R1.05-grizzly
