### PR TITLE
remove version name from nova.egg-info for havana nova builds to remove ...

### DIFF
--- a/openstack/centos_64/nova/openstack-havana-nova.spec
+++ b/openstack/centos_64/nova/openstack-havana-nova.spec
@@ -1000,7 +1000,7 @@ fi
 %defattr(-,root,root,-)
 %doc nova/LICENSE
 %{python_sitelib}/nova
-%{python_sitelib}/nova-%{version}*.egg-info
+%{python_sitelib}/nova-*.egg-info
 
 %if 0%{?with_doc}
 %files doc


### PR DESCRIPTION
...any dependency on git tag
