### PR TITLE
remove version name from nova.egg-info for grizzly build to avoid tag de...

### DIFF
--- a/openstack/centos_64/nova/openstack-nova.spec
+++ b/openstack/centos_64/nova/openstack-nova.spec
@@ -885,7 +885,7 @@ fi
 %defattr(-,root,root,-)
 %doc nova/LICENSE
 %{python_sitelib}/nova
-%{python_sitelib}/nova-%{version}*.egg-info
+%{python_sitelib}/nova-*.egg-info
 
 %if 0%{?with_doc}
 %files doc


### PR DESCRIPTION
...pendency in packaging
