### PR TITLE
moved openstack-config setting for core plugin from python-neutron.posti...

### DIFF
--- a/openstack/debian/openstack-neutron/debian/neutron-common.postinst
+++ b/openstack/debian/openstack-neutron/debian/neutron-common.postinst
@@ -26,6 +26,8 @@ then
 	if [ -f /etc/sudoers.d/neutron_sudoers ] ; then
 		chmod 0440 /etc/sudoers.d/neutron_sudoers
 	fi
+
+   openstack-config --set /etc/neutron/neutron.conf DEFAULT core_plugin neutron.plugins.juniper.contrail.contrail_plugin_core.NeutronPluginContrailCoreV2
 fi
 
 #DEBHELPER#

--- a/openstack/debian/openstack-neutron/debian/python-neutron.postinst
+++ b/openstack/debian/openstack-neutron/debian/python-neutron.postinst
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-set -e 
-
-if [ "$1" = "configure" ]
-then
-  openstack-config --set /etc/neutron/neutron.conf DEFAULT core_plugin neutron.plugins.juniper.contrail.contrail_plugin_core.NeutronPluginContrailCoreV2
-fi
-


### PR DESCRIPTION
...nst to neutron-common.postinst as neutron.conf is owned by neutron-common
