### PR TITLE
Fix build break in centos mainline. PKG-INFO file not present after maki...

### DIFF
--- a/openstack/centos_64/neutron/openstack-neutron.spec
+++ b/openstack/centos_64/neutron/openstack-neutron.spec
@@ -387,7 +387,6 @@ This package contains the neutron Python library.
 #%setup -q -n neutron-%{version}
 
 pushd neutron
-sed -i 's/%{version}/%{version}/' PKG-INFO
 
 find neutron -name \*.py -exec sed -i '/\/usr\/bin\/env python/d' {} \;
 


### PR DESCRIPTION
...ng neutron plugin separate repo
