### PR TITLE
venv is not yet removed in centos, so we need earlier way of launching

### DIFF
--- a/common/control_files/contrail-discovery-centos.ini
+++ b/common/control_files/contrail-discovery-centos.ini
@@ -1,0 +1,10 @@
+[program:contrail-discovery]
+command=/bin/bash -c "source /opt/contrail/api-venv/bin/activate && exec python /opt/contrail/api-venv/lib/python2.7/site-packages/discovery/disc_server_zk.py --conf_file /etc/contrail/discovery.conf"
+priority=430
+autostart=true
+killasgroup=true
+stopsignal=KILL
+redirect_stderr=true
+stdout_logfile=/var/log/contrail/contrail-discovery.log
+stderr_logfile=/dev/null
+exitcodes=0                   ; 'expected' exit codes for process (default 0,2)

--- a/common/control_files/contrail-opserver-centos.ini
+++ b/common/control_files/contrail-opserver-centos.ini
@@ -1,0 +1,17 @@
+[program:contrail-opserver]
+command=bash -c "source /opt/contrail/analytics-venv/bin/activate && exec python /opt/contrail/analytics-venv/bin/contrail-analytics-api -c /etc/contrail/contrail-analytics-api.conf" 
+;command=bash -c "python /opt/contrail/analytics-venv/lib/python2.7/site-packages/opserver/opserver.py --redis_server_port ${REDIS_SERVER_PORT} --redis_query_port ${REDIS_QUERY_PORT} --host_ip ${HOST_IP} --http_server_port 92%(process_num)02d --rest_api_port 93%(process_num)02d --disc_server_ip ${DISCOVERY} --worker_id %(process_num)s"
+;numprocs=3
+;process_name=%(process_num)s
+;stderr_logfile=/var/log/contrail/opserver-%(process_num)s.log
+;stdout_logfile=/var/log/contrail/opserver-%(process_num)s.log
+priority=440
+autostart=true
+killasgroup=true
+stopsignal=KILL
+stdout_capture_maxbytes=1MB 
+redirect_stderr=true
+stdout_logfile=/var/log/contrail/opserver.log
+stderr_logfile=/var/log/contrail/opserver.log
+startsecs=5
+exitcodes=0                   ; 'expected' exit codes for process (default 0,2)

--- a/common/control_files/contrail-schema-centos.ini
+++ b/common/control_files/contrail-schema-centos.ini
@@ -1,0 +1,11 @@
+[program:contrail-schema]
+command=/bin/bash -c "source /opt/contrail/api-venv/bin/activate && exec python /opt/contrail/api-venv/lib/python2.7/site-packages/schema_transformer/to_bgp.py --conf_file /etc/contrail/schema_transformer.conf"
+priority=450
+autostart=true
+autorestart=true
+killasgroup=true
+stopsignal=KILL
+redirect_stderr=true
+stdout_logfile=/var/log/contrail/contrail-schema.log
+stderr_logfile=/dev/null
+exitcodes=0                   ; 'expected' exit codes for process (default 0,2)

--- a/common/control_files/contrail-svc-monitor-centos.ini
+++ b/common/control_files/contrail-svc-monitor-centos.ini
@@ -1,0 +1,10 @@
+[program:contrail-svc-monitor]
+command=/bin/bash -c "source /opt/contrail/api-venv/bin/activate && exec python /opt/contrail/api-venv/lib/python2.7/site-packages/svc_monitor/svc_monitor.py --conf_file /etc/contrail/svc_monitor.conf"
+priority=460
+autostart=true
+killasgroup=true
+stopsignal=KILL
+redirect_stderr=true
+stdout_logfile=/var/log/contrail/contrail-svc-monitor.log
+stderr_logfile=/dev/null
+exitcodes=0                   ; 'expected' exit codes for process (default 0,2)

--- a/common/rpm/contrail-analytics.spec
+++ b/common/rpm/contrail-analytics.spec
@@ -163,7 +163,7 @@ install -p -m 755 %{_distropkgdir}/supervisord_wrapper_scripts/contrail_qe_pre %
 #install .ini files for supervisord
 install -p -m 755 %{_distropkgdir}/supervisord_analytics.conf %{buildroot}%{_contrailetc}/supervisord_analytics.conf
 install -p -m 755 %{_distropkgdir}/contrail-collector.ini %{buildroot}%{_supervisordir}/contrail-collector.ini
-install -p -m 755 %{_distropkgdir}/contrail-opserver.ini %{buildroot}%{_supervisordir}/contrail-opserver.ini
+install -p -m 755 %{_distropkgdir}/contrail-opserver-centos.ini %{buildroot}%{_supervisordir}/contrail-opserver.ini
 install -p -m 755 %{_distropkgdir}/contrail-qe.ini %{buildroot}%{_supervisordir}/contrail-qe.ini
 install -p -m 755 %{_distropkgdir}/redis-query.ini %{buildroot}%{_supervisordir}/redis-query.ini
 install -p -m 755 %{_distropkgdir}/redis-uve.ini %{buildroot}%{_supervisordir}/redis-uve.ini

--- a/common/rpm/contrail-config.spec
+++ b/common/rpm/contrail-config.spec
@@ -146,9 +146,9 @@ install -D -m 755 %{_distropkgdir}/contrail-svc-monitor.initd.supervisord %{buil
 install -p -m 755 %{_distropkgdir}/supervisord_config.conf %{buildroot}%{_sysconfdir}/contrail/supervisord_config.conf
 install -d -m 755 %{buildroot}%{_sysconfdir}/contrail/supervisord_config_files
 install -p -m 755 %{_distropkgdir}/contrail-api.ini %{buildroot}%{_sysconfdir}/contrail/supervisord_config_files/contrail-api.ini
-install -p -m 755 %{_distropkgdir}/contrail-schema.ini %{buildroot}%{_sysconfdir}/contrail/supervisord_config_files/contrail-schema.ini
-install -p -m 755 %{_distropkgdir}/contrail-svc-monitor.ini %{buildroot}%{_sysconfdir}/contrail/supervisord_config_files/contrail-svc-monitor.ini
-install -p -m 755 %{_distropkgdir}/contrail-discovery.ini %{buildroot}%{_sysconfdir}/contrail/supervisord_config_files/contrail-discovery.ini
+install -p -m 755 %{_distropkgdir}/contrail-schema-centos.ini %{buildroot}%{_sysconfdir}/contrail/supervisord_config_files/contrail-schema.ini
+install -p -m 755 %{_distropkgdir}/contrail-svc-monitor-centos.ini %{buildroot}%{_sysconfdir}/contrail/supervisord_config_files/contrail-svc-monitor.ini
+install -p -m 755 %{_distropkgdir}/contrail-discovery-centos.ini %{buildroot}%{_sysconfdir}/contrail/supervisord_config_files/contrail-discovery.ini
 install -p -m 755 %{_distropkgdir}/supervisord_wrapper_scripts/contrail-api.kill %{buildroot}%{_sysconfdir}/contrail/supervisord_config_files/contrail-api.kill
 install -p -m 755 %{_distropkgdir}/contrail-config.rules %{buildroot}%{_sysconfdir}/contrail/supervisord_config_files/contrail-config.rules
 install -D -m 755 %{_distropkgdir}/zookeeper.initd %{buildroot}%{_initddir}/zookeeper


### PR DESCRIPTION
the python daemons..
