### PR TITLE
Adding third party depends package (python-chardet) to Ubuntu

### DIFF
--- a/build/package_configs/ubuntu1204/grizzly/depends_packages.cfg
+++ b/build/package_configs/ubuntu1204/grizzly/depends_packages.cfg
@@ -1367,3 +1367,8 @@ md5   = 4e71a0abd78ca4985fd49b6530673170
 [python-jsonpickle]
 file  = python-jsonpickle_0.4.0-1build1_all.deb
 md5   = 88737e6cf3de4cd23f18a89dec51be0c
+
+[python-chardet]
+file  = python-chardet_2.0.1-2build2_all.deb
+md5   = a4e008069af3cb800d58c7f13cb3c7ed
+

--- a/build/package_configs/ubuntu1204/havana/depends_packages.cfg
+++ b/build/package_configs/ubuntu1204/havana/depends_packages.cfg
@@ -1743,3 +1743,8 @@ md5   = 4e71a0abd78ca4985fd49b6530673170
 [python-jsonpickle]
 file  = python-jsonpickle_0.4.0-1build1_all.deb
 md5   = 88737e6cf3de4cd23f18a89dec51be0c
+
+[python-chardet]
+file  = python-chardet_2.0.1-2build2_all.deb
+md5   = a4e008069af3cb800d58c7f13cb3c7ed
+


### PR DESCRIPTION
Adding third party depends package (python-chardet) to Ubuntu
