### PR TITLE
- Use modprobe instead of insmod. Also, no need to hardcode the version ...

### DIFF
--- a/common/control_files/vnagent_param_setup_ubuntu.sh
+++ b/common/control_files/vnagent_param_setup_ubuntu.sh
@@ -1,7 +1,5 @@
 #! /bin/bash
 
-OS_VER=$1
-
 CFG_FILE=/etc/contrail/agent_param.tmpl
 
 if [ -f $CFG_FILE ] ; then
@@ -17,7 +15,7 @@ echo CONFIG=$CONFIG >> $CFG_FILE
 prog=/usr/bin/vnswad
 echo prog=$prog >> $CFG_FILE
 
-kmod=/lib/modules/${OS_VER}/extra/net/vrouter/vrouter.ko
+kmod=vrouter
 echo kmod=$kmod >> $CFG_FILE
 
 pname=$(basename $prog)

--- a/common/control_files/vrouter-functions.sh
+++ b/common/control_files/vrouter-functions.sh
@@ -23,7 +23,7 @@ function pkt_setup () {
 function insert_vrouter() {
     grep $kmod /proc/modules 1>/dev/null 2>&1
     if [ $? != 0 ]; then 
-        insmod $kmod
+        modprobe $kmod
         if [ $? != 0 ]
         then
             echo "$(date) : Error inserting vrouter module"

--- a/common/debian/contrail-openstack-vrouter/debian/contrail-openstack-vrouter.postinst
+++ b/common/debian/contrail-openstack-vrouter/debian/contrail-openstack-vrouter.postinst
@@ -2,7 +2,7 @@
 set -e
 
 #echo "create the agent_param file..."
-#/etc/contrail/vnagent_param_setup.sh 3.2.0-35-generic
+#/etc/contrail/vnagent_param_setup.sh
 
 echo "Running Postinst ldconfig .."
 if [ ! -f /etc/ld.so.conf.d/contrail-libs.conf ]; then

--- a/common/debian/contrail-vrouter-init/debian/contrail-vrouter-init.postinst
+++ b/common/debian/contrail-vrouter-init/debian/contrail-vrouter-init.postinst
@@ -1,7 +1,6 @@
 #!/bin/sh
 set -e
 
-kver=`uname -r`
 echo "create the agent_param file..."
-/opt/contrail/bin/vnagent_param_setup.sh $kver
+/opt/contrail/bin/vnagent_param_setup.sh
 


### PR DESCRIPTION
...and

paths to be used for kernel module.

Unfortunately, modprobe doesn't seem to work the way it is expected in Centos.
Hence, not changing the centos parts
