### PR TITLE
Initial checkin for storage stats daemon

### DIFF
--- a/storage/control_files/storage-stats.upstart
+++ b/storage/control_files/storage-stats.upstart
@@ -1,0 +1,10 @@
+description "Storage statistics daemon"
+author "Shreya Kunjir <shreyak@juniper.net>"
+
+start on runlevel [2345] or storage-stats
+stop on runlevel [!2345]
+
+respawn
+respawn limit 5 30
+
+exec /usr/bin/python /usr/lib/python2.7/site-packages/storage_stats/storage-nodemgr.py --nodetype=storage-compute --discovery_server /etc/contrail/storage_nodemgr_param 

--- a/storage/debian/contrail-storage/debian/rules
+++ b/storage/debian/contrail-storage/debian/rules
@@ -22,14 +22,34 @@ BUILDTAG = $(SRC_VER)-$(TAG)
 else
 BUILDTAG = $(SRC_VER)-$(BUILDTIME)
 endif
+TARGETS=controller/src/storage/stats-daemon
+export _srcdir = $(SB_TOP)/build/python_dist
+export _build_dist := $(SB_TOP)/build/debug
+export _venv_root := /usr
+export _venvtr := --prefix=$(_venv_root)
+export _src_config := $(SB_TOP)/tools/packaging/storage/control_files
+export _sysconfdir := /etc
 
+__python ?= /usr/bin/python
 %:
 	dh $@ --tmpdir=${buildroot} --destdir=${SB_TOP}/build/debian
 
 override_dh_auto_build:
 	cat debian/changelog.in | sed 's,BUILDTAG,$(BUILDTAG),g' > debian/changelog
+	(cd ${SB_TOP}; scons ${TARGETS})
+
+	mkdir -p $(_srcdir)
+	(cd $(_srcdir); tar zxf $(_build_dist)/storage/stats-daemon/dist/storage_stats-0.1dev.tar.gz)
+
 
 override_dh_auto_install:
+
+#	Install storage_nodemgr 
+	(cd $(_srcdir)/storage_stats-0.1dev; $(__python) setup.py install --root=$(buildroot) $(_venvtr))
+	#install -D -m 644 $(_src_config)/stats_daemon.conf $(buildroot)$(_sysconfdir)/contrail/stats_daemon.conf
+	mkdir -p ${buildroot}/etc/init
+	install -p -m 644 $(_src_config)/storage-stats.upstart ${buildroot}/etc/init/storage-stats.conf
+
 
 override_dh_usrlocal:
 


### PR DESCRIPTION
storage-stats.upstart : init script to start/restart storage stats daemon
rules: this is file has been modified to have build and installation of stats
       daemon.
