### PR TITLE
1. Add process connection info for python daemons. Currently reported by

### DIFF
--- a/common/control_files/contrail-nodemgr.py
+++ b/common/control_files/contrail-nodemgr.py
@@ -170,11 +170,11 @@ class EventManager:
 
         if (self.node_type == 'contrail-analytics'):
             try:
-                from opserver.sandesh.analytics_cpuinfo.ttypes import *
-                from opserver.sandesh.analytics_cpuinfo.cpuinfo.ttypes import *
+                from opserver.sandesh.analytics.ttypes import *
+                from opserver.sandesh.analytics.cpuinfo.ttypes import *
             except:
-                from analytics_cpuinfo.ttypes import *
-                from analytics_cpuinfo.cpuinfo.ttypes import *
+                from analytics.ttypes import *
+                from analytics.cpuinfo.ttypes import *
 
 	if (self.node_type == 'contrail-database'):
             from database.sandesh.database_cpuinfo.ttypes import *
@@ -428,11 +428,11 @@ def main(argv=sys.argv):
         # ubuntu packaging is different, figure out where the generated files 
         # are installed
         try:
-            from opserver.sandesh.analytics_cpuinfo.ttypes import *
+            from opserver.sandesh.analytics.ttypes import *
             sandesh_pkg_dir = 'opserver.sandesh'
         except:
-            from analytics_cpuinfo.ttypes import *
-            sandesh_pkg_dir = 'analytics_cpuinfo'
+            from analytics.ttypes import *
+            sandesh_pkg_dir = 'analytics'
         sandesh_global.init_generator(module_name, socket.gethostname(), 
             node_type_name, instance_id, collector_addr,
             module_name, 8104, [sandesh_pkg_dir],_disc)


### PR DESCRIPTION
   opserver.
2. Add updation of process connection info from discovery client and
   sandesh client python libraries.
