### PR TITLE
Adding ruby-json to storage packaging.

### DIFF
--- a/build/package_configs/ubuntu1204/havana/depends_storage_packages.cfg
+++ b/build/package_configs/ubuntu1204/havana/depends_storage_packages.cfg
@@ -176,3 +176,6 @@ md5   = dd3332b91d8a3ca454eebe71416978a7
 file  = libsensors4_3.3.1-2ubuntu1_amd64.deb
 md5   = d8a23ca9c92f8e57dd6aee0a20b409e4
 
+[ruby-json]
+file  = ruby-json_1.6.3-1_amd64.deb
+md5   = 60512a21163973f1b714dad68ee276e0


### PR DESCRIPTION
 This is needed for the contrail-storage puppet module.
